### PR TITLE
Improve game design and playability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -93,3 +93,40 @@
   margin: 0.2em;
   border: 2px wheat dotted;
 }
+
+.Controls {
+  margin: 1em;
+}
+
+.Controls button {
+  margin: 0 0.5em;
+  padding: 0.4em 1em;
+  font-size: 1em;
+  cursor: pointer;
+  border: 1px solid #333;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+}
+
+.Controls button:hover {
+  background-color: #e0e0e0;
+}
+
+.Scoreboard {
+  font-family: monospace;
+  font-size: 1.2em;
+  color: #fff;
+  margin-bottom: 1em;
+}
+
+/* word states */
+.Word.used {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.Word.correct {
+  background-color: lightgreen;
+  color: #000;
+  font-weight: 700;
+}

--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -7,6 +7,8 @@ export default function Layout() {
   const [editorText, setEditorText] = useState('');
   const [evidenceText, setEvidenceText] = useState('');
   const [currentReference, setCurrentReference] = useState('');
+  const [score, setScore] = useState(0);
+  const [wasComplete, setWasComplete] = useState(false);
 
   const { reference, verse, randomVerse } = useBible({});
 
@@ -22,6 +24,18 @@ export default function Layout() {
     setEditorText(_editorText);
   };
 
+  // track verse completion to update score once per verse
+  const verseComplete = evidenceText.trim().length > 0 && evidenceText.trim() === editorText.trim();
+
+  useEffect(() => {
+    if (verseComplete && !wasComplete) {
+      setScore(prev => prev + 1);
+      setWasComplete(true);
+    } else if (!verseComplete && wasComplete) {
+      setWasComplete(false);
+    }
+  }, [verseComplete, wasComplete]);
+
   // GAMEPLAY CONTROLS -----------------------
   const undoLastWord = () => {
     const words = editorText.trim().split(/\s+/);
@@ -36,6 +50,7 @@ export default function Layout() {
     setEvidenceText(newVerse);
     setCurrentReference(newRef);
     setEditorText('');
+    setWasComplete(false);
   };
 
   return (
@@ -49,6 +64,8 @@ export default function Layout() {
         <button onClick={clearEditor}>Clear</button>
         <button onClick={nextVerse}>Next Verse</button>
       </div>
+
+      <div className="Scoreboard">Score: {score}</div>
 
       <Desk
         editorText={editorText}

--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -6,16 +6,36 @@ import useBible from "./hooks/useBible";
 export default function Layout() {
   const [editorText, setEditorText] = useState('');
   const [evidenceText, setEvidenceText] = useState('');
+  const [currentReference, setCurrentReference] = useState('');
 
-  const { reference, verse } = useBible({});
+  const { reference, verse, randomVerse } = useBible({});
 
   useEffect(() => {
-    setEvidenceText(verse);
-  }, [verse]);
+    if (verse) {
+      setEvidenceText(verse);
+      setCurrentReference(reference);
+    }
+  }, [verse, reference]);
 
   const addWordToEditorText = ({word}) => {
     const _editorText = [ editorText.trim(), word ].join(' ').trim();
     setEditorText(_editorText);
+  };
+
+  // GAMEPLAY CONTROLS -----------------------
+  const undoLastWord = () => {
+    const words = editorText.trim().split(/\s+/);
+    words.pop();
+    setEditorText(words.join(' '));
+  };
+
+  const clearEditor = () => setEditorText('');
+
+  const nextVerse = () => {
+    const { reference: newRef, verse: newVerse } = randomVerse();
+    setEvidenceText(newVerse);
+    setCurrentReference(newRef);
+    setEditorText('');
   };
 
   return (
@@ -23,11 +43,18 @@ export default function Layout() {
       <div className="BackWall">
       </div>
       <ComputerScreen editorText={editorText} onEditorText={setEditorText} />
+
+      <div className="Controls">
+        <button onClick={undoLastWord}>Undo</button>
+        <button onClick={clearEditor}>Clear</button>
+        <button onClick={nextVerse}>Next Verse</button>
+      </div>
+
       <Desk
         editorText={editorText}
         evidenceText={evidenceText}
         addWordToEditorText={addWordToEditorText}
-        reference={reference}
+        reference={currentReference}
       />
       <div className="FileCabinet">FileCabinet</div>
     </div>

--- a/src/components/Printout.jsx
+++ b/src/components/Printout.jsx
@@ -1,6 +1,17 @@
+export default function Printout ({ evidenceText = '', editorText = '', reference = '' }) {
+  const evidenceWords = evidenceText.trim().split(/\s+/).filter(Boolean);
+  const editorWords = editorText.trim().split(/\s+/).filter(Boolean);
 
-export default function Printout ({ evidenceText, editorText, reference }) {
-  const printoutText = (evidenceText === editorText) ? evidenceText : 'Keep trying...';
+  const correctWordCount = editorWords.filter((word, index) => word === evidenceWords[index]).length;
 
-  return (<div className="Printout">{printoutText} {reference}</div>);
+  const verseComplete = (evidenceText === editorText) && evidenceText.length > 0;
+
+  let printoutText = '';
+  if (verseComplete) {
+    printoutText = `${evidenceText} (${reference})`;
+  } else {
+    printoutText = `Progress: ${correctWordCount}/${evidenceWords.length} words correct`;
+  }
+
+  return (<div className="Printout">{printoutText}</div>);
 };

--- a/src/components/Word.jsx
+++ b/src/components/Word.jsx
@@ -7,10 +7,14 @@ export default function Word({text, used, correct, addWordToEditorText}) {
   if (correct) className = className + ' correct';
 
   const handleClick = () => {
+    // Prevent adding the word again if it has already been used
+    if (used) return;
     addWordToEditorText({word: text});
   };
 
+  const title = correct ? 'Correct position!' : (used ? 'Already used' : 'Click to add');
+
   return (
-    <span onClick={handleClick} className={className}>{text} </span>
+    <span title={title} onClick={handleClick} className={className}>{text} </span>
   );
 };

--- a/src/hooks/useBible.js
+++ b/src/hooks/useBible.js
@@ -23,6 +23,15 @@ export default function useBible({ reference }) {
         return { reference, verse };
     }, []);
 
+    // Return a random verse from the kjv data set. Useful for "next verse" gameplay.
+    const randomVerse = useCallback(() => {
+        const randomIndex = Math.floor(Math.random() * (lines.length - 1));
+        const line = lines[randomIndex];
+        const { reference, verse } = parseVerseFromLine(line);
+
+        return { reference, verse };
+    }, []);
+
     // const getVerseFromReference = (reference) => {
     //     const line = lines.find((line) => line.includes(reference) );
     //     const [_reference, verse] = line.split('\t');
@@ -37,5 +46,6 @@ export default function useBible({ reference }) {
         setState({ reference, verse });
     }, [verseOfTheDay]);
 
-    return state;
+    // expose the randomVerse helper so consuming components can advance to a new verse at will
+    return { ...state, randomVerse };
 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement core gameplay loop enhancements, including scoring, word state feedback, and UI controls, to improve playability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR completes the core gameplay loop by adding a score counter, preventing re-clicks on used words, and providing clear visual feedback on word states and overall progress. It also introduces UI controls for undoing, clearing, and advancing to a new random verse, significantly enhancing the game's playability and replay value.